### PR TITLE
Fix IntelliJ build, scalaVersion set to 2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import Dependencies.*
 
-val scala3Version = "3.2.2"
+val scala3Version = "3.3.0"
 val scala2Version = "2.13.10"
 
 lazy val commonSettings = Seq(
@@ -23,16 +23,21 @@ lazy val settingsScala2 = commonSettings ++ Seq(
   Compile / compile / wartremoverErrors ++= WartsSettings.DEFAULTS_SCALA_2,
 )
 
+lazy val rhonix = (project in file("."))
+  .settings(commonSettings*)
+  .aggregate(sdk, weaver, dproc, node)
+
 lazy val sdk = (project in file("sdk"))
-  .settings(settingsScala3*)
+//  .settings(settingsScala3*) // Not supported in IntelliJ Scala plugin
+  .settings(settingsScala2*)
   .settings(
     libraryDependencies ++= Seq(catsCore, catsEffect, fs2Core) ++ tests,
   )
 
 // Consensus
 lazy val weaver = (project in file("weaver"))
-//  .settings(settingsScala3 *)
-  .settings(settingsScala2*) // TEMP: Scala 2 project
+//  .settings(settingsScala3*) // Not supported in IntelliJ Scala plugin
+  .settings(settingsScala2*)
   .settings(
     libraryDependencies ++= Seq(catsCore, catsEffect, fs2Core) ++ tests,
   )
@@ -40,8 +45,8 @@ lazy val weaver = (project in file("weaver"))
 
 // Node logic
 lazy val dproc = (project in file("dproc"))
-  .settings(settingsScala3*)
-//  .settings(settingsScala2 *) // Compile error for Sync in classpath
+//  .settings(settingsScala3*) // Not supported in IntelliJ Scala plugin
+  .settings(settingsScala2*)
   .settings(
     libraryDependencies ++= Seq(catsCore, catsEffect, fs2Core) ++ tests,
   )
@@ -49,8 +54,8 @@ lazy val dproc = (project in file("dproc"))
 
 // Node implementation
 lazy val node = (project in file("node"))
-  .settings(settingsScala3*)
-//  .settings(settingsScala2 *) // Compilation of tests fail
+//  .settings(settingsScala3*) // Not supported in IntelliJ Scala plugin
+  .settings(settingsScala2*)
   .settings(
     libraryDependencies ++= Seq(catsCore, catsEffect, protobuf, grpc, grpcNetty) ++ tests,
   )

--- a/project/CompilerOptions.scala
+++ b/project/CompilerOptions.scala
@@ -38,11 +38,10 @@ object CompilerOptions {
 
       // Scala linter options
       "-Xlint:_",
-      "-Xlint:adapted-args",
-      "-Xlint:inaccessible",
-      "-Wunused:-imports",  // Disables warning for unused imports
+      "-Xlint:-adapted-args",
+      "-Wunused:-imports", // Disables warning for unused imports
       "-Wunused:-privates", // Disables warning for unused private vars
-      "-Wunused:-locals",   // Disables warning for unused local vars
+      "-Wunused:-locals", // Disables warning for unused local vars
       // Scala bug false positive warnings - https://github.com/scala/bug/issues/12072
       "-Xlint:-byname-implicit",
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,9 +2,9 @@ import sbt.*
 
 object Dependencies {
   // Core dependencies
-  val catsCore   = "org.typelevel" %% "cats-core"   % "2.9.0" cross CrossVersion.for2_13Use3
-  val catsEffect = "org.typelevel" %% "cats-effect" % "3.5.0" cross CrossVersion.for2_13Use3
-  val fs2Core    = "co.fs2"        %% "fs2-core"    % "3.7.0" cross CrossVersion.for2_13Use3
+  val catsCore   = "org.typelevel" %% "cats-core"   % "2.9.0" // cross CrossVersion.for3Use2_13
+  val catsEffect = "org.typelevel" %% "cats-effect" % "3.5.0" // cross CrossVersion.for3Use2_13
+  val fs2Core    = "co.fs2"        %% "fs2-core"    % "3.7.0" // cross CrossVersion.for3Use2_13
 
   // Network communication
   val grpc      = "io.grpc" % "grpc-core"  % "1.53.0"
@@ -14,8 +14,8 @@ object Dependencies {
   val protobuf = "com.google.protobuf" % "protobuf-java" % "3.22.2"
 
   // Testing frameworks
-  val scalatest    = "org.scalatest" %% "scalatest"                     % "3.2.15" % Test cross CrossVersion.for2_13Use3
-  val scalatest_ce = "org.typelevel" %% "cats-effect-testing-scalatest" % "1.4.0"  % Test cross CrossVersion.for2_13Use3
+  val scalatest    = "org.scalatest" %% "scalatest"                     % "3.2.15" % Test // cross CrossVersion.for3Use2_13
+  val scalatest_ce = "org.typelevel" %% "cats-effect-testing-scalatest" % "1.4.0"  % Test // cross CrossVersion.for3Use2_13
 
   val tests = Seq(scalatest, scalatest_ce)
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.9.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.1.3")
-addSbtPlugin("org.scalameta"   % "sbt-scalafmt"    % "2.4.0")
+addSbtPlugin("org.wartremover" % "sbt-wartremover"    % "3.1.3")
+addSbtPlugin("org.scalameta"   % "sbt-scalafmt"       % "2.4.0")
+addSbtPlugin("ch.epfl.scala"   % "sbt-scala3-migrate" % "0.5.1") // Temp for migration to Scala 3

--- a/sdk/src/main/scala/sdk/primitive/MapSyntax.scala
+++ b/sdk/src/main/scala/sdk/primitive/MapSyntax.scala
@@ -2,15 +2,24 @@ package sdk.primitive
 
 import scala.collection.mutable
 
-trait MapSyntax:
-  extension [K, V](map: Map[K, V])
-    def getUnsafe(k: K): V =
-      val vOpt = map.get(k)
-      require(vOpt.isDefined, s"No key $k in a map.")
-      vOpt.get
+trait MapSyntax {
+  implicit final def mapSyntax[K, V](value: Map[K, V]): MapOps[K, V]                       = new MapOps[K, V](value)
+  implicit final def mutableMapSyntax[K, V](value: mutable.Map[K, V]): MutableMapOps[K, V] =
+    new MutableMapOps[K, V](value)
+}
 
-  extension [K, V](map: mutable.Map[K, V])
-    def getUnsafe(k: K): V =
-      val vOpt = map.get(k)
-      require(vOpt.isDefined, s"No key $k in a map.")
-      vOpt.get
+final class MapOps[K, V](private val map: Map[K, V]) extends AnyVal {
+  def getUnsafe(k: K): V = {
+    val vOpt = map.get(k)
+    require(vOpt.isDefined, s"No key $k in a map.")
+    vOpt.get
+  }
+}
+
+final class MutableMapOps[K, V](private val map: mutable.Map[K, V]) extends AnyVal {
+  def getUnsafe(k: K): V = {
+    val vOpt = map.get(k)
+    require(vOpt.isDefined, s"No key $k in a map.")
+    vOpt.get
+  }
+}

--- a/weaver/src/main/scala/weaver/Weaver.scala
+++ b/weaver/src/main/scala/weaver/Weaver.scala
@@ -21,7 +21,7 @@ final case class Weaver[M, S, T](
     else if (minGenJs.forall(lazo.contains)) {
       val fromOffender = {
         val selfJs = minGenJs.filter(lazo.dagData(_).sender == sender)
-        val fromEquivocator = selfJs.size > 1
+        val fromEquivocator = selfJs.sizeIs > 1
         lazy val selfJsIsOffence = selfJs.headOption.exists(lazo.offences.contains)
         fromEquivocator || selfJsIsOffence
       }

--- a/weaver/src/main/scala/weaver/rules/Basic.scala
+++ b/weaver/src/main/scala/weaver/rules/Basic.scala
@@ -52,7 +52,7 @@ object Basic {
     sender: M => S
   ): Option[InvalidUnambiguity[S, M]] = {
     val pardons = justifications.groupBy(sender).collect {
-      case (s, jss) if jss.size > 1 && (jss -- offences).nonEmpty => s -> jss
+      case (s, jss) if jss.sizeIs > 1 && (jss -- offences).nonEmpty => s -> jss
     }
     pardons.nonEmpty.guard[Option].as(InvalidUnambiguity(pardons))
   }

--- a/weaver/src/main/scala/weaver/rules/Dag.scala
+++ b/weaver/src/main/scala/weaver/rules/Dag.scala
@@ -55,7 +55,7 @@ object Dag {
   def between[M](ceiling: Set[M], floor: Set[M], seen: M => Set[M]): Set[M] =
     ceiling.flatMap(seen) ++ ceiling -- floor.flatMap(seen)
 
-  def seenByAll[M](x: Set[M], seenMap: Map[M, Set[M]]) = x.map(seenMap).reduce(_ intersect _)
+  def seenByAll[M](x: Set[M], seenMap: Map[M, Set[M]]): Set[M] = x.map(seenMap).fold(Set())(_ intersect _)
 //  def seenBySome[M](x: Set[M], seenMap: Map[M, Set[M]]) = x.flatMap(seenMap)
 //
 //  def inTheView[M](target: M, observers: Set[M], seenMap: Map[M, Set[M]]) =


### PR DESCRIPTION
# Overview

Any combination of mixing Scala versions 2.13 and 3 causes errors with IntelliJ IDE. Tested both with stable and nightly release of Scala plugin.

The solution is to keep all projects on the same Scala version. The first obstacle are libraries that are not converted to Scala 3 and use macros which cannot be shared between version 2.13 and 3.